### PR TITLE
Add sub aud config

### DIFF
--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-const testIssuer = "vault-plugin-secrets-jwt:test"
+const testIssuer = ""
 
 func getTestBackend(t *testing.T) (*backend, *logical.Storage) {
 	config := &logical.BackendConfig{

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -2,7 +2,6 @@ package jwtsecrets
 
 import (
 	"regexp"
-	"strings"
 	"time"
 )
 
@@ -13,7 +12,6 @@ const (
 	DefaultSetIAT            = true
 	DefaultSetJTI            = true
 	DefaultSetNBF            = true
-	DefaultIssuer            = "vault-plugin-secrets-jwt:UUID"
 	DefaultAudiencePattern   = ".*"
 	DefaultSubjectPattern    = ".*"
 	DefaultMaxAudiences      = -1
@@ -23,6 +21,7 @@ const (
 // By default only the 'aud' and 'sub' claims can be set by the caller.
 var DefaultAllowedClaims = []string{"aud", "sub"}
 
+// ReservedClaims are claims that can't be dynamically altered
 var ReservedClaims = []string{"iss", "exp", "nbf", "iat", "jti"}
 
 // Config holds all configuration for the backend.
@@ -44,6 +43,12 @@ type Config struct {
 
 	// Issuer defines the 'iss' claim for the jwt. If blank, it is omitted.
 	Issuer string
+
+	// Audience defines the 'aud' claim for the jwt. If blank, it is omitted.
+	Audience string
+
+	// Subject defines the 'sub' claim for the jwt. If blank, it is omitted.
+	Subject string
 
 	// AudiencePattern defines a regular expression (https://golang.org/pkg/regexp/) which must be matched by any incoming 'aud' claims.
 	// If the audience claim is an array, each element in the array must match the pattern.
@@ -70,7 +75,6 @@ func DefaultConfig(backendUUID string) *Config {
 	c.SetIAT = DefaultSetIAT
 	c.SetJTI = DefaultSetJTI
 	c.SetNBF = DefaultSetNBF
-	c.Issuer = strings.Replace(DefaultIssuer, "UUID", backendUUID, 1)
 	c.AudiencePattern = regexp.MustCompile(DefaultAudiencePattern)
 	c.SubjectPattern = regexp.MustCompile(DefaultSubjectPattern)
 	c.MaxAudiences = DefaultMaxAudiences

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -16,6 +16,8 @@ const (
 	keySetJTI              = "set_jti"
 	keySetNBF              = "set_nbf"
 	keyIssuer              = "issuer"
+	keyAudience            = "audience"
+	keySubject             = "subject"
 	keyAudiencePattern     = "audience_pattern"
 	keySubjectPattern      = "subject_pattern"
 	keyMaxAllowedAudiences = "max_audiences"
@@ -49,6 +51,14 @@ func pathConfig(b *backend) *framework.Path {
 			keyIssuer: {
 				Type:        framework.TypeString,
 				Description: `Value to set as the 'iss' claim. Claim is omitted if empty.`,
+			},
+			keyAudience: {
+				Type:        framework.TypeString,
+				Description: `Value to set as the 'aud' claim. Claim is omitted if empty.`,
+			},
+			keySubject: {
+				Type:        framework.TypeString,
+				Description: `Value to set as the 'sub' claim. Claim is omitted if empty.`,
 			},
 			keyAudiencePattern: {
 				Type:        framework.TypeString,
@@ -119,6 +129,14 @@ func (b *backend) pathConfigWrite(c context.Context, r *logical.Request, d *fram
 		b.config.Issuer = newIssuer.(string)
 	}
 
+	if newAudience, ok := d.GetOk(keyAudience); ok {
+		b.config.Audience = newAudience.(string)
+	}
+
+	if newSubject, ok := d.GetOk(keySubject); ok {
+		b.config.Subject = newSubject.(string)
+	}
+
 	if newAudiencePattern, ok := d.GetOk(keyAudiencePattern); ok {
 		pattern, err := regexp.Compile(newAudiencePattern.(string))
 		if err != nil {
@@ -185,6 +203,8 @@ set_iat:          Whether or not the backend should generate and set the 'iat' c
 set_jti:          Whether or not the backend should generate and set the 'jti' claim.
 set_nbf:          Whether or not the backend should generate and set the 'nbf' claim.
 issuer:           Value to set as the 'iss' claim. Claim omitted if empty.
+audience:         Value to set as the 'aud' claim. Claim omitted if empty.
+subject:          Value to set as the 'sub' claim. Claim omitted if empty.
 audience_pattern: Regular expression which must match incoming 'aud' claims.
 subject_pattern:  Regular expression which must match incoming 'sub' claims.
 max_audiences:    Maximum number of allowed audiences, or -1 for no limit.

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -181,6 +181,8 @@ func nonLockingRead(b *backend) (*logical.Response, error) {
 			keySetJTI:              b.config.SetJTI,
 			keySetNBF:              b.config.SetNBF,
 			keyIssuer:              b.config.Issuer,
+			keyAudience:            b.config.Audience,
+			keySubject:             b.config.Subject,
 			keyAudiencePattern:     b.config.AudiencePattern.String(),
 			keySubjectPattern:      b.config.SubjectPattern.String(),
 			keyMaxAllowedAudiences: b.config.MaxAudiences,

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -13,6 +13,8 @@ const (
 	secondUpdatedRotationPeriod = "1h0m0s"
 	updatedTTL                  = "6m0s"
 	newIssuer                   = "new-vault"
+	newAud                      = "aud"
+	newSub                      = "sub"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -137,6 +139,66 @@ func TestWriteConfig(t *testing.T) {
 
 	if diff := deep.Equal(newIssuer, issuer); diff != nil {
 		t.Error("unexpected issuer:", diff)
+	}
+}
+
+func TestWriteAudSubConfig(t *testing.T) {
+	b, storage := getTestBackend(t)
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config",
+		Storage:   *storage,
+		Data: map[string]interface{}{
+			keyAudience: newAud,
+			keySubject:  newSub,
+		},
+	}
+
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	rotationPeriod := resp.Data[keyRotationDuration].(string)
+	tokenTTL := resp.Data[keyTokenTTL].(string)
+	setIAT := resp.Data[keySetIAT].(bool)
+	setJTI := resp.Data[keySetJTI].(bool)
+	setNBF := resp.Data[keySetNBF].(bool)
+	issuer := resp.Data[keyIssuer].(string)
+	aud := resp.Data[keyAudience].(string)
+	sub := resp.Data[keySubject].(string)
+
+	if diff := deep.Equal(DefaultKeyRotationPeriod, rotationPeriod); diff != nil {
+		t.Error("failed to update rotation period:", diff)
+	}
+
+	if diff := deep.Equal(DefaultTokenTTL, tokenTTL); diff != nil {
+		t.Error("expiry period should be unchanged:", diff)
+	}
+
+	if diff := deep.Equal(DefaultSetIAT, setIAT); diff != nil {
+		t.Error("set_iat should be unchanged:", diff)
+	}
+
+	if diff := deep.Equal(DefaultSetJTI, setJTI); diff != nil {
+		t.Error("set_jti should be unchanged:", diff)
+	}
+
+	if diff := deep.Equal(DefaultSetNBF, setNBF); diff != nil {
+		t.Error("set_nbf should be unchanged:", diff)
+	}
+
+	if diff := deep.Equal(testIssuer, issuer); diff != nil {
+		t.Error("unexpected issuer:", diff)
+	}
+
+	if diff := deep.Equal(newAud, aud); diff != nil {
+		t.Error("unexpected aud:", diff)
+	}
+
+	if diff := deep.Equal(newSub, sub); diff != nil {
+		t.Error("unexpected sub:", diff)
 	}
 }
 

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -116,6 +116,8 @@ func TestWriteConfig(t *testing.T) {
 	setJTI = resp.Data[keySetJTI].(bool)
 	setNBF = resp.Data[keySetNBF].(bool)
 	issuer = resp.Data[keyIssuer].(string)
+	aud := resp.Data[keyAudience].(string)
+	sub := resp.Data[keySubject].(string)
 
 	if diff := deep.Equal(secondUpdatedRotationPeriod, rotationPeriod); diff != nil {
 		t.Error("failed to update rotation period:", diff)
@@ -139,6 +141,14 @@ func TestWriteConfig(t *testing.T) {
 
 	if diff := deep.Equal(newIssuer, issuer); diff != nil {
 		t.Error("unexpected issuer:", diff)
+	}
+
+	if diff := deep.Equal("", aud); diff != nil {
+		t.Error("unexpected aud:", diff)
+	}
+
+	if diff := deep.Equal("", sub); diff != nil {
+		t.Error("unexpected sub:", diff)
 	}
 }
 

--- a/plugin/path_sign.go
+++ b/plugin/path_sign.go
@@ -31,14 +31,13 @@ func pathSign(b *backend) *framework.Path {
 }
 
 func (b *backend) pathSignWrite(_ context.Context, _ *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	claims := make(map[string]interface{})
 	rawClaims, ok := d.GetOk("claims")
-	if !ok {
-		return logical.ErrorResponse("no claims provided"), logical.ErrInvalidRequest
-	}
-
-	claims, ok := rawClaims.(map[string]interface{})
-	if !ok {
-		return logical.ErrorResponse("claims not a map"), logical.ErrInvalidRequest
+	if ok {
+		claims, ok = rawClaims.(map[string]interface{})
+		if !ok {
+			return logical.ErrorResponse("claims not a map"), logical.ErrInvalidRequest
+		}
 	}
 
 	// Get a local copy of config, to minimize time with the lock
@@ -75,6 +74,12 @@ func (b *backend) pathSignWrite(_ context.Context, _ *logical.Request, d *framew
 
 	if config.Issuer != "" {
 		claims["iss"] = config.Issuer
+	}
+	if config.Audience != "" {
+		claims["aud"] = config.Audience
+	}
+	if config.Subject != "" {
+		claims["sub"] = config.Subject
 	}
 
 	if rawSub, ok := claims["sub"]; ok {

--- a/plugin/path_sign_test.go
+++ b/plugin/path_sign_test.go
@@ -78,6 +78,41 @@ func TestSign(t *testing.T) {
 	}
 }
 
+func TestSignWithAudSub(t *testing.T) {
+	b, storage := getTestBackend(t)
+
+	b.config.Subject = "sub"
+	b.config.allowedClaimsMap["sub"] = true
+	b.config.Audience = "aud"
+	b.config.allowedClaimsMap["aud"] = true
+
+	claims := map[string]interface{}{
+		"aud": []string{"Zapp Brannigan", "Kif Kroker"},
+	}
+
+	var decoded jwt.Claims
+	if err := getSignedToken(b, storage, claims, &decoded); err != nil {
+		t.Fatalf("%v\n", err)
+	}
+
+	expectedExpiry := jwt.NumericDate(5 * 60)
+	expectedIssuedAt := jwt.NumericDate(0)
+	expectedNotBefore := jwt.NumericDate(0)
+	expectedClaims := jwt.Claims{
+		Audience:  []string{"Zapp Brannigan", "Kif Kroker"},
+		Expiry:    &expectedExpiry,
+		IssuedAt:  &expectedIssuedAt,
+		NotBefore: &expectedNotBefore,
+		ID:        "1",
+		Issuer:    testIssuer,
+		Subject:   "sub",
+	}
+
+	if diff := deep.Equal(expectedClaims, decoded); diff != nil {
+		t.Error(diff)
+	}
+}
+
 type customToken struct {
 	Foo string `json:"foo"`
 }


### PR DESCRIPTION
# What

Add sub and aud to plugin path configuration

# Why

This allows us to set those claims upon configuration and us the `read` directive (next PR) to get token instead of the `write` directive. Our kubevault only supports using `read` directives to get secrets.

# Usage

```
vault write jwt/config "sub=<your subject>" "aud=<your aud>"
```