### PR TITLE
disable CGO

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: wangyoucao577/go-release-action@master
+      env:
+        CGO_ENABLED: "0"
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux


### PR DESCRIPTION
From [here](https://stackoverflow.com/questions/36279253/go-compiled-binary-wont-run-in-an-alpine-docker-container-on-ubuntu-host) there might be a problem with the binary for alpine. CGO=0 might fix it.