### PR TITLE
marshal private key to pkcs8

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ vault write jwt/<key_name>/sign @claims.json
 
 ### Keys
 
-Returns the generated private key, in base64 encoded PEM format.
+Returns the generated private key, in base64 encoded in PKCS8 PEM format.
 
 Example
 ```

--- a/plugin/secrets_keys.go
+++ b/plugin/secrets_keys.go
@@ -100,11 +100,16 @@ func (b *backend) pathKeysRead(ctx context.Context, r *logical.Request, d *frame
 		b.Logger().Error("Failed to get keys.", "error", err)
 		return logical.ErrorResponse("failed to get keys"), err
 	}
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(key.Key)
+	if err != nil {
+		b.Logger().Error("Failed to get keys.", "error", err)
+		return logical.ErrorResponse("marchal key to pkcs8"), err
+	}
 
 	pem := pem.EncodeToMemory(
 		&pem.Block{
-			Type:  "RSA PRIVATE KEY",
-			Bytes: x509.MarshalPKCS1PrivateKey(key.Key),
+			Type:  "PRIVATE KEY",
+			Bytes: pkcs8,
 		},
 	)
 

--- a/plugin/secrets_keys_test.go
+++ b/plugin/secrets_keys_test.go
@@ -47,7 +47,7 @@ func TestGetNewKey(t *testing.T) {
 	// Check if pem correspond to original key
 	block, _ := pem.Decode([]byte(respB.Data["pem"].([]byte)))
 	assert.NotEmpty(t, block)
-	priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	assert.NoError(t, err, "Should not error")
 
 	rawKey, err := req.Storage.Get(context.Background(), fmt.Sprintf("%s/%s", keysPath("pathB"), respB.Data["id"]))


### PR DESCRIPTION
# What

Uses pkcs8 encoding for private key instead of pkcs1.